### PR TITLE
Modify lesson to be a little more beginner friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,309 +2,114 @@
 
 ## Learning Goals
 
-- Define OAuth
-- Implement OAuth
+- Define OAuth and explain how it works.
 
 ## Introduction
 
-OAuth is an open standard that allows a user, to grant an application, such as
-the one we're building here, access to the user's information that is stored and
-managed by a third party.
+In the last lesson, we learned about authorization and how we could authorize a
+user by checking for certain permissions once in our application. To do this, we
+used HTTP basic to authorize the user - which is checking the user by its
+username, password, and the authorities the user holds.
 
-For example, a user might want to allow your application to use their Google
-account information in order to validate who they are and give them permissions
-to perform specific actions. In this scenario, and in OAuth parlance, we have
-the following components:
+But what if we didn't always want to provide username and password credentials?
+For example, say we downloaded a new application, and it gives us the option to
+login with Facebook instead of creating an account. If we choose that option, it
+may take us to Facebook where we can say we will allow this app permission to
+see some information gathered from the Facebook profile. After agreeing, it will
+direct us to the new app we downloaded.
 
-1. The user is the "Resource Owner", i.e. the person whose credentials are being
-   validated. The "credentials" are the resource being owned here.
-2. Google is both the "Authorization Server" and the "Resource Server".
-   1. The "Authentication Server" is responsible for generating an "Access
-      Token" once it has validated that you are who you say you are
-   2. The "Resource Server" is responsible for providing whatever protected
-      resource is being requested
-3. The "Client" is the application that is requesting access to the protected
-   resource.
+So what happened here? Did Facebook share our username and password credentials
+with the application?
 
-## OAuth in Spring
+## What is OAuth?
 
-The Spring Framework provides support for OAuth, so let's explore this mechanism
-more by implementing it for our application.
+"**OAuth**, short for Open Authorization, is a standard designed to allow an
+application to access resources hosted by other web apps on behalf of a user in
+order to provide consented access and restricted actions of what the client app
+can perform without ever sharing the user's credentials"
+([What is OAuth 2.0?](https://auth0.com/intro-to-iam/what-is-oauth-2)).
 
-Since we're about to add static content to our sample application, let's first
-clean up our existing URLs to make an explicit distinction between our
-"endpoints" and our "content". We'll do this by moving all our existing
-endpoints to a "/api/" base URL:
+This is the exact authorization process that happened in the example scenario
+described above: We were able to access the new application without having to
+create an account by linking it to our Facebook, allowing that application to
+access resources hosted by Facebook on behalf of the user in order to provide
+consented access and restricted actions.
 
-```java
-    @GetMapping("/api/hello")
-    public String hello(@RequestParam(name = "targetName", defaultValue = "Stephanie") String name) {
-        String greeting = "Hello " + name;
-        greeting += "<br/>";
-        greeting += "Dad joke of the moment: " + jokeService.getDadJoke();
-        return greeting;
-    }
+So back to the question, did Facebook share our username and password with the
+application?
 
-    @GetMapping("/api/status")
-    public String status() {
-        return "Congratulations - you must be an admin since you can see the application's status information";
-    }
-```
+OAuth does **not** share passwords or sensitive information. Instead, OAuth will
+work with something called an **access token**. Access tokens are generated and
+provided to access resources, which is then passed to the application to grant
+the appropriate permissions. These tokens come in a specific format, usually as
+a **JSON Web Token** or JWT.
 
-This means you have to update all your integration and acceptance tests to make
-them use the updated URLs - you should be able to do that on your own.
+## How Does OAuth Work?
 
-We also need to update our security configuration to only require authentication
-for the API-based URLs, as we want our static content to be accessible to
-anyone, at least for now:
+Let's look at the process of how OAuth may work. Assume we have an application,
+and we are going to use GitHub as our OAuth provider. This means, in order to be
+authorized to our application, we'll need to link our application to our GitHub
+account so that it can provide the application a token, allowing us into the
+application.
 
-```java
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-            .antMatchers("/api/status")
-            .hasAuthority("admin");
-
-        http.authorizeRequests()
-            .antMatchers("/api/**")
-            .authenticated()
-            .and()
-            .formLogin()
-            .and()
-            .logout();
-    }
-```
-
-## Simple UI
-
-Now let's add a simple `index.html` page to our `src/main/resources/static`
-project folder:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Demo</title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width" />
-    <base href="/" />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/webjars/bootstrap/css/bootstrap.min.css"
-    />
-    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
-    <script
-      type="text/javascript"
-      src="/webjars/bootstrap/js/bootstrap.min.js"
-    ></script>
-  </head>
-  <body>
-    <h1>Demo</h1>
-    <div class="container"></div>
-  </body>
-</html>
-```
-
-Let's make sure Bootstrap and jQuery are available by adding the corresponding
-dependencies to our project:
-
-- Gradle:
-
-```json
-	implementation 'org.webjars:webjars-locator-core'
-	implementation 'org.webjars:jquery:3.6.0'
-	implementation 'org.webjars:bootstrap:5.1.3'
-```
-
-- Maven:
-
-```xml
-<dependency>
-	<groupId>org.webjars</groupId>
-	<artifactId>jquery</artifactId>
-	<version>3.4.1</version>
-</dependency>
-<dependency>
-	<groupId>org.webjars</groupId>
-	<artifactId>bootstrap</artifactId>
-	<version>4.3.1</version>
-</dependency>
-<dependency>
-	<groupId>org.webjars</groupId>
-	<artifactId>webjars-locator-core</artifactId>
-</dependency>
-```
-
-## Using GitHub as the OAuth Provider
-
-First, we need to add Spring's OAuth support to our project by adding the
-following dependencies:
-
-- Gradle
-
-```json
-	implementation 'org.springframework.security:spring-security-oauth2-resource-server'
-	implementation 'org.springframework.security:spring-security-oauth2-jose'
-	implementation 'org.springframework.security:spring-security-oauth2-client'
-```
-
-- Maven
-
-```xml
-<dependency>
-	<groupId>org.springframework.security</groupId>
-	<artifactId>spring-security-oauth2-resource-server</artifactId>
-</dependency>
-<dependency>
-	<groupId>org.springframework.security</groupId>
-	<artifactId>spring-security-oauth2-jose</artifactId>
-</dependency>
-<dependency>
-	<groupId>org.springframework.security</groupId>
-	<artifactId>spring-security-oauth2-client</artifactId>
-</dependency>
-```
-
-There are many OAuth providers - since we can be sure every single one of you
-has a GitHub account, we will use GH as the OAuth provider.
-
-Log in to your GitHub account and go to
-`https://github.com/settings/developers`:
-
-![GH Dev Settings](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-gh-dev-settings.png)
-
-Click on the button to "Register a new application" and fill out the following
-details:
-
-![GH OAuth New Application](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-gh-new-application.png)
-
-We are using all default values for your application settings:
-
-1. Homepage URL: is the base URL for your application - your port number might
-   be different if you've customized your application settings
-2. Authorization callback URL: we're using the default value here as well, so
-   adjust accordingly if you've updated the defaults
-
-Registering the application will take you to a screen that confirms that the
-application has been registered and shows you your Client ID, which has been
-blurred here for obvious reasons:
-
-![GH OAuth Client ID](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-gh-client-id.png)
-
-Select the option to generate a "Client Secret" as well.
-
-You should have 2 values on your GH Developer Settings for the "Flatiron Spring
-Security Training" application you just created:
-
-1. Client ID: this identifies your application so that the OAuth provider
-   (GitHub in this case) can look up the settings associated with your
-   application when it (your application) requests access on behalf of the user
-2. Client Secret: this is a "password" of sorts that only your client
-   application should know, so that it can prove to GH that it is authorized to
-   make the request it's making
-
-Note: in this simple sample application, we are storing the client secret in our
-source code. This should generally not be the case for production application
-because many more people have access to your source code (especially when you
-work within large organizations) than are supposed to have access to your
-"secrets". All cloud providers have "secret managers" that let applications
-manage their secrets for different environments.
-
-Make sure to copy your client secret in a safe place where you can use it in a
-moment when we configure the application. Once you refresh this page, your
-client secret will no longer be visible (for security reasons) and you will not
-be able to retrieve it.
-
-![GH OAuth Client Secret](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-gh-client-secret.png)
-
-Now we have to change our security configuration to ask the static content to be
-authenticated with OAuth2:
-
-```java
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-            .antMatchers("/api/status")
-            .hasAuthority("admin");
-
-        http.authorizeRequests()
-            .antMatchers("/api/**")
-            .authenticated()
-            .and()
-            .formLogin()
-            .and()
-            .logout();
-
-        // adding a rule to require authentication for all content via OAuth
-        http.authorizeRequests()
-            .anyRequest()
-            .authenticated()
-            .and()
-            .oauth2Login();
-    }
-```
-
-If you restart your application now and try to access your "index.html", you
-will notice that you have both `httpBasic` and `oauth` login enabled:
-
-![GH OAuth and HTTP Basic](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-gh-and-http-basic.png)
-
-This is because we have mixed both authentication methods in our security
-configuration. Let's clean that up by setting our API access to also use OAuth
-authentication:
-
-```java
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-            .antMatchers("/api/status")
-            .hasAuthority("admin");
-
-        http.authorizeRequests()
-            .antMatchers("/api/**")
-            .authenticated()
-            .and()
-            .oauth2Login() // change httpBasic() to oauth2Login() for API resources
-            .and()
-            .logout();
-
-        http.authorizeRequests()
-            .anyRequest()
-            .authenticated()
-            .and()
-            .oauth2Login();
-    }
-```
-
-You should now be redirected to GitHub for all login requests.
-
-Let's summarize the high level flow of operations in order for the OAuth
-provider, in this case GitHub, to provide the user information to the client, in
-this case your application:
+Consider the following diagram:
 
 ![Spring OAuth Flow](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-oauth-flow.png)
 
-1. The security configuration in our application results in our application
-   sending an Authorization Request to GitHub whenever the user tries to access
-   a restricted resource, which in our case is any resource
-2. Our user needs to grant our application permission to interact with the OAuth
-   Provider (GitHub) on their behalf - that's what the Authorization Grant
-   represents
-3. The Spring Framework OAuth support then automatically sends the OAuth
-   Provider the Authorization Grant, which GH then validates
-4. Upon Authorization Grant validation, GH returns an Access Token, which can
-   then be used to request specific resources from the OAuth Provider
-5. The client (your application) can then use the Access Token to request
-   resources from the OAuth Provider. In our case, the Spring Framework OAuth
-   support requests user information from GH
-6. GH returns user information and we now have an authenticated user in our
-   application context
+Before we explain the entire process, let's define the following:
 
-## Conclusion
+**Resource Owner**: This is typically the end-user or another server
+requesting authorization.
 
-We have learned about OAuth and added GitHub OAuth to the project. It is usually
-better to use an external auth service since keeping up with latest security
-patches and maintaining your own auth service can take up a lot of resources.
+**Client**: This is the application that the resource owner interfaces with and
+performs the protected requests made.
+
+**Authorization Server**: This is responsible for generating an access token
+after authenticating the resource owner.
+
+**Resource Server**: This is responsible for providing whatever protected
+resource is being requested.
+
+In the diagram above...
+
+1. The resource owner and end-user are the same since it is a human-being making
+   the request out to the client.
+2. Once the request is sent to the application, the application will come back
+   asking the user to grant permission to interact with GitHub on their behalf -
+   that's what the Authorization Grant represents.
+3. The application then automatically sends the Authorization Grant to the
+   authorization server (or GitHub in this example).
+4. The authorization server then redirects back to the client with an
+   authorization code, letting the application know that the user may be
+   authorized with a generated access token.
+5. In order for the user to be authorized on the client side, it makes a request
+   out to the resource server with the access token to access specific
+   resources.
+6. The resource server will then provide the application with the appropriate
+   user information to fully have the user authorized.
+
+This is the same process if we were to download an app and login using
+Facebook or Google!
+
+OAuth is considered a standard in the industry when it comes to authorization
+since it does not share sensitive information, like a password, making it more
+secure.
+
+## OAuth in Spring
+
+We can implement OAuth using the Spring Framework as well! To do this, you will
+need to add the "Oauth2 Resource Server" dependency to the `pom.xml` file.
+
+In this lesson, we will not cover how to exactly implement this feature, but if
+curious, please see the Spring documentation along with these other helpful
+tutorials:
+
+- [OAuth 2.0 Resource Server](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/index.html)
+- [Djamware: Spring Boot, Security, PostgreSQL, and Keycloak REST API OAuth2](https://www.djamware.com/post/6225b66ba88c55c95abca0b6/spring-boot-security-postgresql-and-keycloak-rest-api-oauth2#create-spring-boot)
+- [[Video] Laur Spilca: Spring Security Fundamentals - Lesson 11 - The OAuth Authorization Server](https://youtu.be/N0LiMIGCDgg)
+
+## References
+
+- [What is OAuth 2.0?](https://auth0.com/intro-to-iam/what-is-oauth-2)
+- [Introduction to API Gateway OAuth 2.0 Server](https://docs.oracle.com/cd/E55956_01/doc.11123/oauth_guide/content/oauth_intro.html#:~:text=An%20entity%20capable%20of%20granting,resource%20requests%20using%20access%20tokens.)
+- [The Difference Between Basic Auth and OAuth](https://squareball.co/blog/the-difference-between-basic-auth-and-oauth)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ provided to access resources, which is then passed to the application to grant
 the appropriate permissions. These tokens come in a specific format, usually as
 a **JSON Web Token** or JWT.
 
+Consider a valet key. Most cars nowadays come with a special key we could
+provide to a valet driver. The valet key only allows the valet to start the car.
+The key will not open the trunk nor the glove box. We can think of that valet
+key as the access token in an OAuth scenario.
+
 ## How Does OAuth Work?
 
 Let's look at the process of how OAuth may work. Assume we have an application,
@@ -90,6 +95,9 @@ In the diagram above...
 
 This is the same process if we were to download an app and login using
 Facebook or Google!
+
+Consider another real world analogy here:
+[OAuth explained with real life example](https://lunaticmonk.medium.com/oauth-explained-with-real-life-example-f0386ad63637).
 
 OAuth is considered a standard in the industry when it comes to authorization
 since it does not share sensitive information, like a password, making it more


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

- After talking with Jay, Linda, and Alvee, the consensus was to teach students what OAuth is and how it works rather than focus on the implementation of it since students will not be expected to implement this in their projects. (OAuth also made it difficult to test in one student's project, per Jay). 
- Lesson was rewritten to include a high-level overview of what OAuth is and the process. 
- Provided documentation and other tutorials that students may use if they choose to try implementing OAuth on their own.